### PR TITLE
Improve configurations and more rails-y approach

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,17 @@
+source "https://rubygems.org"
+
+gemspec
+
+group :development, :test do
+  gem "rspec"
+  gem "pry"
+  gem "byebug"
+end
+
+group :test do
+  gem "activerecord"
+  gem "rspec-rails"
+  gem "sqlite3"
+  gem "bcrypt"
+  gem "jwt"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,190 @@
+PATH
+  remote: .
+  specs:
+    api_authentication_gem (0.1.4)
+      bcrypt
+      jwt
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (8.0.2)
+      actionview (= 8.0.2)
+      activesupport (= 8.0.2)
+      nokogiri (>= 1.8.5)
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+      useragent (~> 0.16)
+    actionview (8.0.2)
+      activesupport (= 8.0.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activemodel (8.0.2)
+      activesupport (= 8.0.2)
+    activerecord (8.0.2)
+      activemodel (= 8.0.2)
+      activesupport (= 8.0.2)
+      timeout (>= 0.4.0)
+    activesupport (8.0.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    base64 (0.2.0)
+    bcrypt (3.1.20)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
+    builder (3.3.0)
+    byebug (12.0.0)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.1)
+    crass (1.0.6)
+    date (3.4.1)
+    diff-lcs (1.6.1)
+    drb (2.2.1)
+    erubi (1.13.1)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.0)
+    irb (1.15.2)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    jwt (2.10.1)
+      base64
+    logger (1.7.0)
+    loofah (2.24.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    method_source (1.1.0)
+    minitest (5.25.5)
+    nokogiri (1.18.7-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.7-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.7-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.7-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.18.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.7-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.7-x86_64-linux-musl)
+      racc (~> 1.4)
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    psych (5.2.3)
+      date
+      stringio
+    racc (1.8.1)
+    rack (3.1.13)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rack-test (2.2.0)
+      rack (>= 1.3)
+    rackup (2.2.1)
+      rack (>= 3)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.2)
+      loofah (~> 2.21)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    railties (8.0.2)
+      actionpack (= 8.0.2)
+      activesupport (= 8.0.2)
+      irb (~> 1.13)
+      rackup (>= 1.0.0)
+      rake (>= 12.2)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
+    rake (13.2.1)
+    rdoc (6.13.1)
+      psych (>= 4.0.0)
+    reline (0.6.1)
+      io-console (~> 0.5)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.3)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-rails (7.1.1)
+      actionpack (>= 7.0)
+      activesupport (>= 7.0)
+      railties (>= 7.0)
+      rspec-core (~> 3.13)
+      rspec-expectations (~> 3.13)
+      rspec-mocks (~> 3.13)
+      rspec-support (~> 3.13)
+    rspec-support (3.13.2)
+    securerandom (0.4.1)
+    sqlite3 (2.6.0-aarch64-linux-gnu)
+    sqlite3 (2.6.0-aarch64-linux-musl)
+    sqlite3 (2.6.0-arm-linux-gnu)
+    sqlite3 (2.6.0-arm-linux-musl)
+    sqlite3 (2.6.0-arm64-darwin)
+    sqlite3 (2.6.0-x86_64-darwin)
+    sqlite3 (2.6.0-x86_64-linux-gnu)
+    sqlite3 (2.6.0-x86_64-linux-musl)
+    stringio (3.1.6)
+    thor (1.3.2)
+    timeout (0.4.3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.3)
+    useragent (0.16.11)
+    zeitwerk (2.7.2)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  activerecord
+  api_authentication_gem!
+  bcrypt
+  byebug
+  jwt
+  pry
+  rspec
+  rspec-rails
+  sqlite3
+
+BUNDLED WITH
+   2.5.23

--- a/README.md
+++ b/README.md
@@ -12,59 +12,84 @@ No need to write boilerplate authentication code again — just plug it in, and 
 - ✅ Login with JWT token generation
 - ✅ Easy integration with any Rails API
 - ✅ Customizable user model support
+- ✅ Configurable `secret_key` and `user_class`
+- ✅ Tested with RSpec
+- ✅ Rails-friendly design
 
 ---
 
 ## 📦 Installation
 
 Add this line to your Rails application's `Gemfile`:
-gem 'api_authentication_gem'
+`gem 'api_authentication_gem'`
 Then run:
-bundle install
+`bundle install`
 
 🛠 Setup in Your Rails API
-1. Generate the User Model (if not already created)
-rails generate model User email:string password_digest:string
-rails db:migrate
+1. Add gem configs to your app:
+   ```ruby
+   # config/initializers/api_authentication_gem.rb
 
-2. Create a Controller to Handle Auth Actions
+    ApiAuthenticationGem.configure do |config|
+      config.secret_key = ENV["SECRET_KEY_BASE"] || "fallback-key" # Always set your secret_key via environment variable in production
+      config.user_class = "User"
+    end
+   ```
 
-class UsersController < ApplicationController
-  def signup
-    result = ApiAuthenticationGem::Auth.signup(
-      email: params[:email],
-      password: params[:password],
-      user_class: User
-    )
+2. Generate the User Model (if not already created)
+   ```bash
+   rails generate model User email:string password_digest:string
+   rails db:migrate
+   ```
 
-    if result[:error]
-      render json: { error: result[:error] }, status: :unprocessable_entity
-    else
-      render json: { message: result[:message], user: result[:user] }, status: :created
+Your User model must use has_secure_password:
+  ```ruby
+  class User < ApplicationRecord
+    has_secure_password
+  end
+  ```
+No need to manually validate emails or handle password_digest — the gem takes care of it internally.
+
+3. Create a Controller to Handle Auth Actions
+
+  ```ruby
+  class UsersController < ApplicationController
+    def signup
+      result = ApiAuthenticationGem::Auth.signup(
+        email: params[:email],
+        password: params[:password]
+      )
+
+      if result[:error]
+        render json: { error: result[:error] }, status: :unprocessable_entity
+      else
+        render json: { message: result[:message], user: result[:user] }, status: :created
+      end
+    end
+
+    def login
+      result = ApiAuthenticationGem::Auth.login(
+        email: params[:email],
+        password: params[:password]
+      )
+
+      if result[:error]
+        render json: { error: result[:error] }, status: :unauthorized
+      else
+        render json: { token: result[:token] }, status: :ok
+      end
     end
   end
-
-  def login
-    result = ApiAuthenticationGem::Auth.login(
-      email: params[:email],
-      password: params[:password],
-      user_class: User
-    )
-
-    if result[:error]
-      render json: { error: result[:error] }, status: :unauthorized
-    else
-      render json: { token: result[:token] }, status: :ok
-    end
-  end
-end
+  ```
 
 
 3. Define Routes
 In your config/routes.rb file:
-Rails.application.routes.draw do
-  post 'signup', to: 'users#signup'
-  post 'login', to: 'users#login'
-end
+  ```ruby
+    Rails.application.routes.draw do
+      post 'signup', to: 'users#signup'
+      post 'login', to: 'users#login'
+    end
+  ```
 
 

--- a/api_authentication_gem.gemspec
+++ b/api_authentication_gem.gemspec
@@ -1,15 +1,17 @@
 Gem::Specification.new do |s|
     s.name        = "api_authentication_gem"
-    s.version     = "0.1.3"
+    s.version     = "0.1.4"
     s.summary     = "Provides JWT-based signup and login for APIs"
     s.description = "Reusable gem for authentication with user-defined models. For detailed usage, visit: https://github.com/Adarsh-07-Mishra/api_authentication_gem/blob/main/README.md"
     s.authors     = ["Adarsh Mishra"]
     s.email       = ["aadimishra24@gmail.com"]
     s.files       = Dir["lib/**/*", "README.md"]
-   s.homepage    = "https://github.com/Adarsh-07-Mishra/api_authentication_gem"
+    s.homepage    = "https://github.com/Adarsh-07-Mishra/api_authentication_gem"
     s.license     = "MIT"
   
     s.add_dependency "bcrypt"
     s.add_dependency "jwt"
+    s.add_development_dependency "rspec"
+    s.add_development_dependency "rspec-rails"
   end
   

--- a/lib/api_authentication_gem.rb
+++ b/lib/api_authentication_gem.rb
@@ -1,36 +1,13 @@
-require "jwt"
-require "bcrypt"
+require "api_authentication_gem/version"
+require "api_authentication_gem/configuration"
+require "api_authentication_gem/auth"
 
 module ApiAuthenticationGem
-  class Auth
-    SECRET_KEY = "your$ecretK3y"
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
 
-    def self.signup(email:, password:, user_class:)
-      return { error: "Email is required" } unless email
-      return { error: "Password must be at least 5 characters long" } if password.nil? || password.length < 5
-
-      return { error: "Email already exists" } if user_class.find_by(email: email)
-
-      password_digest = BCrypt::Password.create(password)
-      user = user_class.create(email: email, password_digest: password_digest)
-
-      { message: "User created", user: user }
-    end
-
-    def self.login(email:, password:, user_class:)
-      user = user_class.find_by(email: email)
-
-      return { error: "Invalid email or password" } unless user
-      return { error: "Invalid email or password" } unless BCrypt::Password.new(user.password_digest) == password
-
-      token = JWT.encode({ user_id: user.id, exp: Time.now.to_i + 3600 }, SECRET_KEY, 'HS256')
-      { token: token }
-    end
-
-    def self.decode_token(token)
-      JWT.decode(token, SECRET_KEY, true, { algorithm: 'HS256' })[0]
-    rescue
-      nil
-    end
+  def self.configure
+    yield(configuration)
   end
 end

--- a/lib/api_authentication_gem/auth.rb
+++ b/lib/api_authentication_gem/auth.rb
@@ -1,0 +1,36 @@
+require "jwt"
+module ApiAuthenticationGem
+  class Auth
+    def self.signup(email:, password:)
+      user_class = ApiAuthenticationGem.configuration.user_class.constantize
+      user = user_class.create!(email: email, password: password)
+      token = generate_token(user.id)
+      { token: token, user: user }
+    end
+    
+    def self.login(email:, password:)
+      user_class = ApiAuthenticationGem.configuration.user_class.constantize
+      user = user_class.find_by(email: email)
+      return nil unless user&.authenticate(password)
+    
+      token = generate_token(user.id)
+      { token: token, user: user }
+    end
+    
+
+    # Decode the JWT token and retrieve the payload
+    def self.decode(token)
+      decoded = JWT.decode(token, ApiAuthenticationGem.configuration.secret_key, true, algorithm: 'HS256')
+      decoded.first # The payload is in the first element
+    rescue JWT::DecodeError => e
+      nil # If the token is invalid, return nil
+    end
+
+    private
+
+    def self.generate_token(user_id)
+      payload = { user_id: user_id }
+      JWT.encode(payload, ApiAuthenticationGem.configuration.secret_key)
+    end
+  end
+end

--- a/lib/api_authentication_gem/configuration.rb
+++ b/lib/api_authentication_gem/configuration.rb
@@ -1,0 +1,11 @@
+module ApiAuthenticationGem
+  class Configuration
+    attr_accessor :secret_key, :user_class
+
+    def initialize
+      @secret_key = ENV["API_AUTH_SECRET_KEY"] || "your-default-secret-key"
+      @user_class = "User" # Default to 'User' model
+    end
+  end
+end
+

--- a/lib/api_authentication_gem/version.rb
+++ b/lib/api_authentication_gem/version.rb
@@ -1,0 +1,3 @@
+module ApiAuthenticationGem
+  VERSION = "0.1.4"
+end

--- a/spec/api_authentication_gem/auth_spec.rb
+++ b/spec/api_authentication_gem/auth_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe ApiAuthenticationGem::Auth do
+  before do
+    ApiAuthenticationGem.configure do |config|
+      config.secret_key = "test-secret"
+      config.user_class = "User"
+    end
+  end
+
+  let(:email) { "test@example.com" }
+  let(:password) { "securepass" }
+
+  describe ".signup" do
+    it "creates a user and returns token" do
+      result = described_class.signup(email: email, password: password)
+
+      expect(result[:user]).to be_a(User)
+      expect(result[:user].email).to eq(email)
+      expect(result[:token]).to be_a(String)
+    end
+  end
+
+  describe ".login" do
+    before { described_class.signup(email: email, password: password) }
+
+    it "returns token and user for valid login" do
+      result = described_class.login(email: email, password: password)
+      expect(result[:token]).to be_present
+      expect(result[:user].email).to eq(email)
+    end
+
+    it "returns nil for invalid login" do
+      result = described_class.login(email: email, password: "wrong")
+      expect(result).to be_nil
+    end
+  end
+
+  describe ".decode" do
+    it "decodes a valid token" do
+      result = described_class.signup(email: email, password: password)
+      decoded = described_class.decode(result[:token])
+      expect(decoded["user_id"]).to eq(result[:user].id)
+    end
+
+    it "returns nil for invalid token" do
+      expect(described_class.decode("bad.token")).to be_nil
+    end
+  end
+end

--- a/spec/api_authentication_gem/config_spec.rb
+++ b/spec/api_authentication_gem/config_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe ApiAuthenticationGem::Configuration do
+  it "uses default values" do
+    config = ApiAuthenticationGem::Configuration.new
+    expect(config.secret_key).to be_a(String)
+    expect(config.user_class).to eq("User")
+  end
+
+  it "allows custom configuration" do
+    ApiAuthenticationGem.configure do |config|
+      config.secret_key = "custom123"
+      config.user_class = "Admin"
+    end
+
+    config = ApiAuthenticationGem.configuration
+    expect(config.secret_key).to eq("custom123")
+    expect(config.user_class).to eq("Admin")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,24 @@
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../spec_helper", __FILE__)
+
+require "active_record"
+require "bcrypt"
+
+# Simulate a minimal user model
+class User < ActiveRecord::Base
+  has_secure_password
+end
+
+# In-memory DB for quick tests
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Schema.define do
+  create_table :users, force: true do |t|
+    t.string :email
+    t.string :password_digest
+    t.timestamps
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:each) { User.delete_all }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require "bundler/setup"
+require "api_authentication_gem"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end


### PR DESCRIPTION
hi! I really like what you did here with the gem, is super clean and provides an easy plug n play interface for small projects.

I have made a few changes to improve the api_authentication_gem by aligning it with Rails conventions, improving configuration flexibility, and adding full test coverage.

Let me know what you think.

**What has changed?**

- Configuration
  - Added ApiAuthenticationGem::Configuration to support:
  - Custom secret_key (e.g., from ENV["SECRET_KEY_BASE"])
  - Custom user_class (e.g., "User", "Admin")
  - Added ApiAuthenticationGem.configure initializer pattern

- Auth API Refactor
  - Removed need to pass user_class to signup and login
  - Refactored methods to use the configured user class internally
  - Simplified public API to:
    - ApiAuthenticationGem::Auth.signup(email: ..., password: ...)
    - ApiAuthenticationGem::Auth.login(email: ..., password: ...)

- Password Handling
  - Removed manual BCrypt::Password.create
  - Now uses Rails' built-in has_secure_password convention
  - Ensures password encryption and authentication is Rails-native

- JWT Decode Improvements
  - Gracefully handles invalid tokens by returning nil instead of raising
  - Keeps calling code clean and predictable

- Test Framework
  -   Added full RSpec test suite:
  -   signup, login, decode behavior
  -   Configuration validation
  -   Uses in-memory SQLite and a test User model
  -   Added required test dependencies